### PR TITLE
Add hero title classes

### DIFF
--- a/applications.html
+++ b/applications.html
@@ -36,9 +36,9 @@
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 60px;">
         <div class="container">
-            <h1>Applications</h1>
-            <p class="subtitle">Open source applications built on NANDA infrastructure</p>
-            <p>Our commitment to open source drives everything we build. These applications 
+            <h1 class="hero-title">Applications</h1>
+            <p class="hero-subtitle">Open source applications built on NANDA infrastructure</p>
+            <p>Our commitment to open source drives everything we build. These applications
             demonstrate the capabilities of decentralized AI systems built on top of the NANDA index.</p>
         </div>
     </section>

--- a/blog.html
+++ b/blog.html
@@ -37,9 +37,9 @@
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 60px;">
         <div class="container">
-            <h1>Blog</h1>
-            <p class="subtitle">Insights on decentralized AI and the Agentic Web</p>
-            <p>Technical articles, research insights, and community discussions 
+            <h1 class="hero-title">Blog</h1>
+            <p class="hero-subtitle">Insights on decentralized AI and the Agentic Web</p>
+            <p>Technical articles, research insights, and community discussions
             about building decentralized AI systems.</p>
         </div>
     </section>

--- a/events.html
+++ b/events.html
@@ -211,8 +211,8 @@
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 60px;">
         <div class="container">
-            <h1>Events</h1>
-            <p class="subtitle">Community meetings and workshops</p>
+            <h1 class="hero-title">Events</h1>
+            <p class="hero-subtitle">Community meetings and workshops</p>
             <p>Join us for summits, workshops, and networking opportunities in decentralized AI</p>
         </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -35,14 +35,14 @@
 
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 80px;">
-        <div class="container" style="max-width: 900px; text-align: center;">
-            <h1 style="font-size: 64px; font-weight: 300; margin-bottom: 24px; letter-spacing: -2px;">NANDA</h1>
-            <p style="font-size: 24px; font-weight: 400; color: #666; margin-bottom: 32px; line-height: 1.4;">
+        <div class="container">
+            <h1 class="hero-title">NANDA</h1>
+            <p class="hero-subtitle">
                 Networked Agents and Decentralized AI
             </p>
-            <p style="font-size: 18px; color: #888; max-width: 600px; margin: 0 auto; line-height: 1.6;">
-                An open research initiative developing infrastructure for the Agentic Web. 
-                Building decentralized systems that enable autonomous AI agents to collaborate 
+            <p>
+                An open research initiative developing infrastructure for the Agentic Web.
+                Building decentralized systems that enable autonomous AI agents to collaborate
                 without centralized control.
             </p>
         </div>

--- a/papers.html
+++ b/papers.html
@@ -37,9 +37,9 @@
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 60px;">
         <div class="container">
-            <h1>Research Papers</h1>
-            <p class="subtitle">Publications on decentralized AI and the Agentic Web</p>
-            <p>Academic research and technical papers exploring the foundations, 
+            <h1 class="hero-title">Research Papers</h1>
+            <p class="hero-subtitle">Publications on decentralized AI and the Agentic Web</p>
+            <p>Academic research and technical papers exploring the foundations,
             applications, and implications of decentralized AI agent systems.</p>
         </div>
     </section>

--- a/styles.css
+++ b/styles.css
@@ -104,10 +104,11 @@ body {
     padding: 0 24px;
 }
 
-.hero h1 {
-    font-size: 36px;
+
+.hero-title {
+    font-size: 48px;
     font-weight: 700;
-    margin: 0 auto 16px auto;
+    margin: 0 auto 24px auto;
     color: #000000;
     letter-spacing: -0.03em;
     line-height: 1.2;
@@ -115,10 +116,10 @@ body {
     width: 100%;
 }
 
-.hero .subtitle {
-    font-size: 18px;
+.hero-subtitle {
+    font-size: 22px;
     color: #525252;
-    margin: 0 auto 20px auto;
+    margin: 0 auto 28px auto;
     font-weight: 450;
     letter-spacing: -0.01em;
     text-align: center;
@@ -127,7 +128,7 @@ body {
 }
 
 .hero p {
-    font-size: 16px;
+    font-size: 18px;
     color: #525252;
     line-height: 1.6;
     max-width: 600px;
@@ -482,14 +483,14 @@ body {
         padding: 120px 0 60px;
     }
     
-    .hero h1 {
+    .hero-title {
         font-size: 32px;
     }
-    
-    .hero .subtitle {
+
+    .hero-subtitle {
         font-size: 17px;
     }
-    
+
     .hero p {
         font-size: 15px;
     }
@@ -532,7 +533,7 @@ body {
         padding: 100px 0 50px;
     }
     
-    .hero h1 {
+    .hero-title {
         font-size: 28px;
     }
     

--- a/videos.html
+++ b/videos.html
@@ -37,9 +37,9 @@
     <!-- Hero Section -->
     <section class="hero" style="border-bottom: 1px solid #f0f0f0; padding-bottom: 60px;">
         <div class="container">
-            <h1>Videos</h1>
-            <p class="subtitle">Talks and presentations on decentralized AI</p>
-            <p>Watch technical presentations, conference talks, and demonstrations 
+            <h1 class="hero-title">Videos</h1>
+            <p class="hero-subtitle">Talks and presentations on decentralized AI</p>
+            <p>Watch technical presentations, conference talks, and demonstrations
             of NANDA research and applications.</p>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- define `.hero-title` and `.hero-subtitle` styles
- standardize hero title and subtitle markup across pages
- remove inline styles from hero sections for consistency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436eb80370832188f6f7536c726c1a