### PR TITLE
Fix broken navigation by using relative links

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -7,12 +7,12 @@
         </div>
         <nav aria-label="Footer Quick Links" style="min-width: 160px;">
             <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px;">
-                <li><a href="/index.html" class="footer-link">Home</a></li>
-                <li><a href="/index.html#about" class="footer-link">About</a></li>
-                <li><a href="/blog.html" class="footer-link">Blog</a></li>
-                <li><a href="/papers.html" class="footer-link">Papers</a></li>
-                <li><a href="/applications.html" class="footer-link">Applications</a></li>
-                <li><a href="/events.html" class="footer-link">Events</a></li>
+                <li><a href="index.html" class="footer-link">Home</a></li>
+                <li><a href="index.html#about" class="footer-link">About</a></li>
+                <li><a href="blog.html" class="footer-link">Blog</a></li>
+                <li><a href="papers.html" class="footer-link">Papers</a></li>
+                <li><a href="applications.html" class="footer-link">Applications</a></li>
+                <li><a href="events.html" class="footer-link">Events</a></li>
             </ul>
         </nav>
         <div style="min-width: 180px;">

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
     <div class="main-container">
         <!-- About Section -->
         <section class="section" id="about">
-            <a href="/index.html#about" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 32px; font-weight: 600; margin-bottom: 32px;">About</a>
+            <a href="index.html#about" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 32px; font-weight: 600; margin-bottom: 32px;">About</a>
             <p style="font-size: 18px; line-height: 1.7; color: var(--text-secondary); max-width: 700px; margin: 0 auto;">
                 NANDA is a research project focused on creating decentralized infrastructure 
                 for AI agent collaboration. We develop open source tools and protocols that 
@@ -40,13 +40,13 @@
         </section>
         <!-- Research Section -->
         <section class="section">
-            <a href="/papers.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Research</a>
+            <a href="papers.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Research</a>
             <div style="display: flex; flex-direction: column; gap: 24px; align-items: center;">
-                <a href="/papers.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
+                <a href="papers.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
                     <h3 class="item-title">Papers</h3>
                     <p style="color: var(--text-secondary); line-height: 1.5; margin: 0;">Academic research and technical papers on decentralized AI systems.</p>
                 </a>
-                <a href="/videos.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
+                <a href="videos.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
                     <h3 class="item-title">Videos</h3>
                     <p style="color: var(--text-secondary); line-height: 1.5; margin: 0;">Conference talks, technical presentations, and demonstrations.</p>
                 </a>
@@ -54,9 +54,9 @@
         </section>
         <!-- Applications Section -->
         <section class="section">
-            <a href="/applications.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Applications</a>
+            <a href="applications.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Applications</a>
             <div style="display: flex; flex-direction: column; gap: 24px; align-items: center;">
-                <a href="/applications.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
+                <a href="applications.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
                     <h3 class="item-title">Open Source Tools</h3>
                     <p style="color: var(--text-secondary); line-height: 1.5; margin: 0;">Development tools and infrastructure for the Agentic Web.</p>
                 </a>
@@ -64,13 +64,13 @@
         </section>
         <!-- Community Section -->
         <section class="section">
-            <a href="/blog.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Community</a>
+            <a href="blog.html" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 24px; font-weight: 600; margin-bottom: 32px;">Community</a>
             <div style="display: flex; flex-direction: column; gap: 24px; align-items: center;">
-                <a href="/blog.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
+                <a href="blog.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
                     <h3 class="item-title">Blog</h3>
                     <p style="color: var(--text-secondary); line-height: 1.5; margin: 0;">Technical insights and community discussions.</p>
                 </a>
-                <a href="/events.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
+                <a href="events.html" class="item" style="display: block; text-decoration: none; cursor: pointer; max-width: 500px; width: 100%;">
                     <h3 class="item-title">Events</h3>
                     <p style="color: var(--text-secondary); line-height: 1.5; margin: 0;">Workshops, conferences, and community meetings.</p>
                 </a>

--- a/navbar.html
+++ b/navbar.html
@@ -11,13 +11,13 @@
             </a>
         </div>
         <ul class="nav-menu">
-            <li><a href="/index.html" class="nav-link" id="nav-home">Home</a></li>
-            <li><a href="/index.html#about" class="nav-link" id="nav-about">About</a></li>
-            <li><a href="/papers.html" class="nav-link" id="nav-papers">Papers</a></li>
-            <li><a href="/videos.html" class="nav-link" id="nav-videos">Videos</a></li>
-            <li><a href="/blog.html" class="nav-link" id="nav-blog">Blog</a></li>
-            <li><a href="/applications.html" class="nav-link" id="nav-applications">Applications</a></li>
-            <li><a href="/events.html" class="nav-link" id="nav-events">Events</a></li>
+            <li><a href="index.html" class="nav-link" id="nav-home">Home</a></li>
+            <li><a href="index.html#about" class="nav-link" id="nav-about">About</a></li>
+            <li><a href="papers.html" class="nav-link" id="nav-papers">Papers</a></li>
+            <li><a href="videos.html" class="nav-link" id="nav-videos">Videos</a></li>
+            <li><a href="blog.html" class="nav-link" id="nav-blog">Blog</a></li>
+            <li><a href="applications.html" class="nav-link" id="nav-applications">Applications</a></li>
+            <li><a href="events.html" class="nav-link" id="nav-events">Events</a></li>
         </ul>
         <div class="hamburger" aria-label="Open navigation menu" tabindex="0" role="button">
             <span class="bar"></span>


### PR DESCRIPTION
Updated internal navigation links in navbar.html, footer.html, and index.html to use relative paths instead of absolute ones. This ensures that links work correctly when the site is deployed to a subdirectory (e.g., on GitHub Pages) as well as when hosted at the root of a domain.

Checked all other HTML content files; they either already used relative links for internal navigation or contained only external links, requiring no changes.