### PR TITLE
feat: Enhance index.html with further glass styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,9 @@
     <div class="main-container">
         <section class="section" id="about">
             <a href="index.html#about" class="section-title" style="display: block; text-align: center; text-decoration: none; color: var(--accent-color); font-size: 32px; font-weight: 600; margin-bottom: 32px;">About</a>
-            <p style="font-size: 18px; line-height: 1.7; color: var(--text-secondary); max-width: 700px; margin: 0 auto;">NANDA is a research project focused on creating decentralized infrastructure for AI agent collaboration. We develop open source tools and protocols that enable autonomous agents to discover, communicate, and coordinate with each other across distributed networks.</p>
+            <div class="about-text-card">
+                <p style="font-size: 18px; line-height: 1.7; color: var(--text-secondary);">NANDA is a research project focused on creating decentralized infrastructure for AI agent collaboration. We develop open source tools and protocols that enable autonomous agents to discover, communicate, and coordinate with each other across distributed networks.</p>
+            </div>
             <div class="graphic-placeholder" data-placeholder-info="Conceptual graphic about NANDA's mission or decentralized AI" style="margin-top: 30px; text-align: center;">
                 <!-- Placeholder for an illustrative graphic -->
             </div>

--- a/styles.css
+++ b/styles.css
@@ -49,8 +49,8 @@ body {
     padding: 140px 0 80px; text-align: center; width: 100%;
 }
 .hero .container { text-align: center; max-width: 760px; margin: 0 auto; padding: 0 24px; }
-.hero-title { font-size: 40px; /* Typo update */ font-weight: 700; margin: 0 auto 24px auto; color: var(--accent-color); letter-spacing: -0.02em; /* Typo update */ line-height: 1.2; text-align: center; width: 100%; }
-.hero-subtitle { font-size: 20px; /* Typo update */ color: var(--text-secondary); margin: 0 auto 28px auto; font-weight: 450; letter-spacing: -0.01em; text-align: center; width: 100%; max-width: 600px; }
+.hero-title { font-size: 40px; /* Typo update */ font-weight: 700; margin: 0 auto 24px auto; color: var(--accent-color); letter-spacing: -0.02em; /* Typo update */ line-height: 1.2; text-align: center; width: 100%; text-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+.hero-subtitle { font-size: 20px; /* Typo update */ color: var(--text-secondary); margin: 0 auto 28px auto; font-weight: 450; letter-spacing: -0.01em; text-align: center; width: 100%; max-width: 600px; text-shadow: 0 1px 3px rgba(0,0,0,0.1); }
 .hero p { font-size: 17px; /* Typo update */ color: var(--text-secondary); line-height: 1.6; max-width: 600px; margin: 0 auto; text-align: center; width: 100%; }
 
 /* Main Content */
@@ -217,4 +217,18 @@ body {
 .graphic-placeholder::before {
     content: "Placeholder: " attr(data-placeholder-info);
     display: block;
+}
+
+.about-text-card {
+    background: rgba(255, 255, 255, 0.92); /* Slightly more opaque for text background */
+    padding: 28px; /* Slightly more padding */
+    border-radius: 10px; /* Slightly larger radius */
+    box-shadow: 0 4px 12px rgba(0,0,0,0.06); /* Slightly stronger shadow */
+    max-width: 700px;
+    margin: 0 auto 30px auto; /* Centering and bottom margin */
+}
+
+.about-text-card p {
+    margin-bottom: 0; /* Remove default bottom margin from p if card padding is sufficient */
+    /* The existing inline styles for font-size, line-height, color on the p tag will still apply */
 }


### PR DESCRIPTION
This commit applies targeted style enhancements to index.html to create a more "awesome" glass style design, building upon the pervasive glassmorphism already in place.

Key changes:

1.  **Hero Section Text (`styles.css`):**
    *   I added a subtle `text-shadow` to `.hero-title` and `.hero-subtitle` to improve readability and visual depth against the hero section's glass background.

2.  **"About" Section Content (`index.html` & `styles.css`):**
    *   I wrapped the main descriptive paragraph in the "About" section of `index.html` with a new `<div class="about-text-card">`.
    *   I added CSS rules for `.about-text-card` to style it with a very slightly opaque background, padding, border-radius, and a subtle box-shadow. This makes the text block appear as a distinct card element resting on the main glass surface of the `.main-container`.

These refinements aim to improve the visual appeal and structure of specific content elements on the homepage within the established glassmorphism theme.