### PR TITLE
feat: Enhance UI for papers.html with richer card structure

### DIFF
--- a/papers.html
+++ b/papers.html
@@ -20,15 +20,105 @@
         <section class="section">
             <h2 class="section-title">Available Papers</h2>
             <ul class="item-list">
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/decentralized_ML_perspective-16.pdf" target="_blank" rel="noopener"><h3 class="item-title">A Perspective on Decentralizing AI <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/Game%20of%20Agents%20%E2%80%94%20Episode%201_%20Let%20there%20be%20Agents%20_%20by%20Abhishek%20Singh%20_%20Medium.pdf" target="_blank" rel="noopener"><h3 class="item-title">Game of Agents – Episode 1: Let there be Agents <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/Game%20of%20Agents%20%E2%80%94%20Episode%202_%20The%20Great%20Library%20of%20Alexandria%202.0%20_%20by%20Abhishek%20Singh%20_%20Medium.pdf" target="_blank" rel="noopener"><h3 class="item-title">Game of Agents – Episode 2: The Great Library of Alexandria 2.0 <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/v0.21%20Beyond%20DNS%20-%20Unlocking%20the%20%20Internet%20of%20AI%20Agents%20via%20the%20NANDA%20Quilt%20of%20Registries%20and%20Verified%20AgentFacts.pdf" target="_blank" rel="noopener"><h3 class="item-title">Scaling Trust Beyond DNS – NANDA Registry <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/v0.21%20Upgrade%20or%20Switch%20-%20Do%20We%20Need%20a%20New%20Registry%20Architecture%20for%20the%20Internet%20of%20AI%20Agents.pdf" target="_blank" rel="noopener"><h3 class="item-title">Upgrade or Switch – The Need for New Registry <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/NandaRegistry_AgenticChat.pdf" target="_blank" rel="noopener"><h3 class="item-title">Internet of Agents Architecture (Agentic Chat Demo) <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/v0.2%20Survey_of_AI_Agent_Registry_Solutions.pdf" target="_blank" rel="noopener"><h3 class="item-title">Survey of AI Agent Registry Solutions <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/v0.2%20NANDA%20+%20ANS%20Security%20Blueprint_%20A%20Federated%20Registry%20Architecture%20for%20Secure,%20Capability-Aware%20Agent%20Discovery.pdf" target="_blank" rel="noopener"><h3 class="item-title">NANDA + ANS Security Blueprint <i class="fas fa-external-link-alt"></i></h3></a></li>
-        <li><a class="item" href="https://github.com/aidecentralized/nandapapers/blob/main/Collaborative%20Agentic%20AI%20Needs%20Interoperability%20Across%20Ecosystems.pdf" target="_blank" rel="noopener"><h3 class="item-title">Collaborative Agentic AI Needs Interoperability Across Ecosystems <i class="fas fa-external-link-alt"></i></h3></a></li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/decentralized_ML_perspective-16.pdf" target="_blank" rel="noopener">A Perspective on Decentralizing AI <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/Game%20of%20Agents%20%E2%80%94%20Episode%201_%20Let%20there%20be%20Agents%20_%20by%20Abhishek%20Singh%20_%20Medium.pdf" target="_blank" rel="noopener">Game of Agents – Episode 1: Let there be Agents <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/Game%20of%20Agents%20%E2%80%94%20Episode%202_%20The%20Great%20Library%20of%20Alexandria%202.0%20_%20by%20Abhishek%20Singh%20_%20Medium.pdf" target="_blank" rel="noopener">Game of Agents – Episode 2: The Great Library of Alexandria 2.0 <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/v0.21%20Beyond%20DNS%20-%20Unlocking%20the%20%20Internet%20of%20AI%20Agents%20via%20the%20NANDA%20Quilt%20of%20Registries%20and%20Verified%20AgentFacts.pdf" target="_blank" rel="noopener">Scaling Trust Beyond DNS – NANDA Registry <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/v0.21%20Upgrade%20or%20Switch%20-%20Do%20We%20Need%20a%20New%20Registry%20Architecture%20for%20the%20Internet%20of%20AI%20Agents.pdf" target="_blank" rel="noopener">Upgrade or Switch – The Need for New Registry <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/NandaRegistry_AgenticChat.pdf" target="_blank" rel="noopener">Internet of Agents Architecture (Agentic Chat Demo) <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/v0.2%20Survey_of_AI_Agent_Registry_Solutions.pdf" target="_blank" rel="noopener">Survey of AI Agent Registry Solutions <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/v0.2%20NANDA%20+%20ANS%20Security%20Blueprint_%20A%20Federated%20Registry%20Architecture%20for%20Secure,%20Capability-Aware%20Agent%20Discovery.pdf" target="_blank" rel="noopener">NANDA + ANS Security Blueprint <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
+        <li class="item paper-item">
+            <h3 class="item-title">
+                <a href="https://github.com/aidecentralized/nandapapers/blob/main/Collaborative%20Agentic%20AI%20Needs%20Interoperability%20Across%20Ecosystems.pdf" target="_blank" rel="noopener">Collaborative Agentic AI Needs Interoperability Across Ecosystems <i class="fas fa-external-link-alt"></i></a>
+            </h3>
+            <div class="paper-meta">
+                <span class="paper-authors">Authors: Placeholder</span>
+                <span class="paper-date">Published: Date Placeholder</span>
+                <span class="paper-venue">Venue: Venue Placeholder</span>
+            </div>
+            <p class="paper-summary">Summary: Placeholder for a brief summary or abstract snippet...</p>
+        </li>
     </ul>
         </section>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -341,3 +341,55 @@ body.dark-mode {
 .about-text-card p {
     margin-bottom: 0;
 }
+
+/* Styling enhancements for paper items on papers.html */
+.paper-item {
+    /* .item already provides base card styling (bg, border, shadow, border-radius, overall padding) */
+    /* Add a specific left accent border */
+    border-left: 3px solid var(--accent-color);
+    /* Adjust left padding slightly to maintain internal alignment if .item had uniform padding.
+       If .item padding was, e.g., 32px, this makes internal left padding 29px + 3px border.
+       If .item padding was already asymmetric or used logical properties, this might need review.
+       Assuming current .item padding is uniform (e.g. 32px or 24px on mobile). */
+    padding-left: calc(32px - 3px); /* Example for desktop .item padding */
+}
+
+/* Responsive adjustment for paper-item padding-left if .item padding changes */
+@media (max-width: 600px) {
+    .paper-item {
+        padding-left: calc(24px - 3px); /* Example for mobile .item padding */
+    }
+}
+
+.paper-item .item-title {
+    /* Font size, weight, color are already set by general .item-title rule. */
+    /* No specific changes here unless needed after visual review. */
+}
+
+.paper-item .item-title a {
+    /* Font size, weight, color are already set by general .item-title a rule. */
+}
+
+.paper-meta {
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    margin-top: 0.75em; /* Increased space below title */
+    margin-bottom: 1em;  /* Increased space above summary */
+}
+
+.paper-meta span {
+    display: block;
+    margin-bottom: 0.35em; /* Space between meta items */
+    line-height: 1.4; /* Adjust line height for stacked spans */
+}
+
+.paper-meta span:last-child {
+    margin-bottom: 0;
+}
+
+.paper-summary {
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 0; /* As it's the last element in the card */
+}


### PR DESCRIPTION
This commit redesigns the presentation of items on the `papers.html` page.

Key changes:

1.  **HTML Structure (`papers.html`):**
    *   Modified the list items (`<li>`) for each paper to have a new structure.
    *   Each `<li>` now has classes `item paper-item`.
    *   The paper title (`<h3>`) remains a link.
    *   Added new placeholder divs/spans within each list item for:
        *   `div.paper-meta` containing spans for Authors, Published Date, and Venue.
        *   `p.paper-summary` for a brief abstract or summary.
    *   These placeholders currently contain generic text like "Authors: Placeholder".

2.  **CSS Styling (`styles.css`):**
    *   Added new CSS rules to style the enhanced paper item structure:
        *   `.paper-item` now has a left accent border using `var(--accent-color)` and adjusted left padding.
        *   `.paper-meta` is styled for smaller, secondary text with appropriate margins. Spans within it are styled for clear presentation of metadata items.
        *   `.paper-summary` is styled for a brief descriptive text.

This updated structure and styling provide a richer, more organized layout for each paper entry, making the page more informative and visually appealing. It is now ready for population with actual metadata for each paper.